### PR TITLE
Limit icon width to native flex container width

### DIFF
--- a/_sass/linky.scss
+++ b/_sass/linky.scss
@@ -25,6 +25,8 @@ $linky_social_button_color: #fff !default;
     svg {
         height: var(--social-button-size);
         width: var(--social-button-size);
+        max-width: 100%;
+        aspect-ratio: 1 / 1;
 
         &.filled {
             path {


### PR DESCRIPTION
- force 1/1 aspect ratio to be safe

Fixes #1